### PR TITLE
feat: implement rate limiting for counter endpoint

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -30,7 +30,6 @@ function isRateLimited(ip: string): boolean {
   }
 
   entry.count++;
-  rateLimitMap.set(ip, entry);
   return false;
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -85,7 +85,6 @@ router.post('/counter', (req, res) => {
 
   const data = readCounter();
 
-  // Hash değeri farklı ise counter artır
   if (data.lastHash !== hash) {
     data.counter++;
     data.lastHash = hash;
@@ -105,6 +104,16 @@ router.post('/counter', (req, res) => {
     });
   }
 });
+
+// Automatic cleanup for expired rate limit entries
+setInterval(() => {
+  const now = Date.now();
+  for (const [ip, entry] of rateLimitMap.entries()) {
+    if (now - entry.timestamp > RATE_LIMIT_WINDOW) {
+      rateLimitMap.delete(ip);
+    }
+  }
+}, RATE_LIMIT_WINDOW);
 
 const PORT = parseInt(process.env.PORT || '3000');
 app.listen(PORT, () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -77,7 +77,10 @@ router.post('/counter', (req, res) => {
     return;
   }
 
-  const ip = (req.headers['x-forwarded-for'] as string) || req.socket.remoteAddress || '';
+  // Extract only the first IP from x-forwarded-for header
+  const forwardedFor = req.headers['x-forwarded-for'] as string;
+  const ip = forwardedFor?.split(',')[0]?.trim() || req.socket.remoteAddress || '';
+
   if (isRateLimited(ip)) {
     res.json({ error: 'Too many requests. Please try again later.' }, 429);
     return;


### PR DESCRIPTION
## Açıklama
Bruteforce koruması (rate limit) eklendi. Artık /counter endpointine aynı IP adresinden dakikada en fazla 10 POST isteği yapılabiliyor. Limit aşılırsa 429 hatası dönüyor.

## Tür
- [x] Yeni Özellik
- [ ] Hata Düzeltme
- [ ] Dokümantasyon

## Test
- [x] Kod test edildi
- [ ] Birim testleri eklendi/güncellendi

## Notlar
Rate limit için IP adresi, x-forwarded-for veya [remoteAddress](vscode-file://vscode-app/c:/Users/ABTILT/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) üzerinden alınmaktadır. Kodun çalıştığı ortamda proxy varsa, gerçek istemci IP'sinin doğru şekilde iletildiğinden emin olunmalıdır.
